### PR TITLE
Fix 'Cannot query field 'prev' on type "MarkdownRemarkFrontmatter".''

### DIFF
--- a/docs/vim/vim-plugin-docs.md
+++ b/docs/vim/vim-plugin-docs.md
@@ -1,6 +1,8 @@
 ---
 id: vim-plugin-docs
 title: Vim plugin features
+prev: vim-built-in-docs
+next: vim-tabs-buffers-windows
 ---
 
 ## Use FZF


### PR DESCRIPTION
Gatsby needs at least one `prev` reference.